### PR TITLE
hotfix/PageShareBoardByUser_DetailPage

### DIFF
--- a/src/views/PageShareBoardByUser.vue
+++ b/src/views/PageShareBoardByUser.vue
@@ -136,7 +136,7 @@ export default {
   components: {FontAwesomeIcon, Header},
   data() {
     return {
-      pageDetailLink: "pageshareboard/",
+      pageDetailLink: "/pageshareboard/",
       pageListSize: "",
       pageList: {
         id: "",


### PR DESCRIPTION
### PageShareBoardByUser
- 작성자 게시물 더보기에서 게시물을 누르면 기존의 url에 pageDetailLink에 있는 url이 더해져 잘못된 url로 가는 버그가 생겨 "/"를 추가하여 수정