### PR TITLE
hotfix/Thumbnail_object-fit

### DIFF
--- a/src/assets/template/assets/css/main.css
+++ b/src/assets/template/assets/css/main.css
@@ -1591,6 +1591,8 @@ input, select, textarea {
 		.image img {
 			display: block;
 			width: 100%;
+			height: 270px;
+			object-fit: contain;
 			border-radius: 8px;
 		}
 


### PR DESCRIPTION
### Thumbnail object-fit
- 가로가 긴 썸내일 적용 시 박스가 세로로 줄어드는 것이 있어 수정